### PR TITLE
Support discover latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name                           | Default Value                      |  Description                                                                                                        |
 |--------------------------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-| `prysm_version`             | ___unset___                        | __REQUIRED__ Version of prysm to install and run.                                                            |
+| `prysm_version`             | ___unset___                        | __REQUIRED__ Version of prysm to install and run. Specify `latest` to discover the latest released version                                               |
 | `prysm_user`                | prysm                         | prysm user                                                                                                   |
 | `prysm_group`               | prysm                         | prysm group                                                                                                  |
 | `prysm_base_dir`            | /opt/prysm                    | Path to install to                                                                                           |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,13 +3,18 @@
 prysm_user: prysm
 prysm_group: "{{ prysm_user }}"
 prysm_architecture: "amd64"
+
+# Internal variable for version. This can be overriden when it discover the latest version
+# Parameters specify via command line cannot be overriden using set_fact
+_prysm_version: "{{ prysm_version }}"
+
 # Version to install - linux only!
-prysm_download_beacon_url: "https://github.com/prysmaticlabs/prysm/releases/download/{{ prysm_version }}/beacon-chain-{{ prysm_version }}-linux-{{prysm_architecture}}"
-prysm_download_validator_url: "https://github.com/prysmaticlabs/prysm/releases/download/{{ prysm_version }}/validator-{{ prysm_version }}-linux-{{prysm_architecture}}"
+prysm_download_beacon_url: "https://github.com/prysmaticlabs/prysm/releases/download/{{ _prysm_version }}/beacon-chain-{{ _prysm_version }}-linux-{{prysm_architecture}}"
+prysm_download_validator_url: "https://github.com/prysmaticlabs/prysm/releases/download/{{ _prysm_version }}/validator-{{ _prysm_version }}-linux-{{prysm_architecture}}"
 
 # Directory paths
 prysm_base_dir: "/opt/prysm"
-prysm_install_dir: "{{ prysm_base_dir }}/prysm-{{ prysm_version }}"
+prysm_install_dir: "{{ prysm_base_dir }}/prysm-{{ _prysm_version }}"
 prysm_current_dir: "{{ prysm_base_dir }}/current"
 prysm_data_dir: "{{ prysm_base_dir }}/data"
 prysm_validator_data_dir: "{{ prysm_base_dir }}/validatorData"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -35,7 +35,7 @@
     dest: "/etc/logrotate.d/prysm"
   become: true
 
-- name: Get prysm beacon-chain binary to install directory
+- name: Get prysm beacon-chain binary to install directory [version={{ _prysm_version }}]
   ansible.builtin.get_url:
     url: "{{ prysm_download_beacon_url }}"
     dest: "{{ prysm_install_dir }}/prysm-beacon"
@@ -45,7 +45,7 @@
   become: true
   register: get_binary_beacon
 
-- name: Get prysm beacon-chain binary to install directory
+- name: Get prysm validator binary to install directory [version={{ _prysm_version }}]
   ansible.builtin.get_url:
     url: "{{ prysm_download_validator_url }}"
     dest: "{{ prysm_install_dir }}/prysm-validator"

--- a/tasks/latest.yml
+++ b/tasks/latest.yml
@@ -1,0 +1,20 @@
+- name: Get the latest version from GitHub repository
+  ansible.builtin.uri:
+    url: "https://api.github.com/repos/prysmaticlabs/prysm/releases/latest"
+    method: GET
+    status_code: 200
+    return_content: true
+  register: _latest_release_response
+
+- name: Set the version variable
+  ansible.builtin.set_fact:
+    _prysm_version: "{{ _latest_release_response.json.tag_name }}"
+
+- name: Validate the discovered Prysm version
+  ansible.builtin.assert:
+    that: _prysm_version is search("^v[0-9]+\.[0-9]+\.[0-9]+$")
+    fail_msg: "Discovered version [{{ _prysm_version }}] is not valid"
+  
+- name: Information
+  debug:
+    msg: "Latest Prysm version is {{ _prysm_version }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,11 @@
         msg: You must set "prysm_version" for this role to run
       when: prysm_version is not defined
 
+# Retrive latest version when prysm_version == 'latest'
+- name: Include task to retrieve latest version
+  ansible.builtin.include_tasks: "latest.yml"
+  when: prysm_version == 'latest'
+
 - name: Get IP address to bind to if not provided
   include_tasks: "network.yml"
   when: not prysm_host_ip


### PR DESCRIPTION
Ansible role support specifying prysm_version=latest which latest released version will be discovered and installed. Need to use internal variable _prysm_version as command line parameters cannot be override during the Ansible play