### PR TITLE
Remove duplicate logging by relying on bash redirect in template

### DIFF
--- a/tasks/beacon.yml
+++ b/tasks/beacon.yml
@@ -12,7 +12,7 @@
       {{_prysm_beacon_internal_cmdline_args}}
       --datadir={{prysm_data_dir}}
       --verbosity={{prysm_log_level}}
-      --log-file={{prysm_log_dir}}/beacon.log
+      --disable-ephemeral-log-file=true
       --log-format=json
       --jwt-secret={{prysm_jwt_auth_file}}
       --execution-endpoint={{prysm_execution_urls}}

--- a/tasks/validator.yml
+++ b/tasks/validator.yml
@@ -16,7 +16,6 @@
       --beacon-rpc-provider={{ prysm_validator_beacon_interface }}
       --suggested-fee-recipient={{prysm_default_fee_recipient}}
       --verbosity={{prysm_log_level}}
-      --log-file={{prysm_log_dir}}/validator.log
       --log-format=json
       --enable-builder
       --accept-terms-of-use


### PR DESCRIPTION
Disable ephemeral debug logs for beacon

Fixes #8 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Prysm CLI logging flags in Ansible task templates; main impact is where logs are emitted/rotated.
> 
> **Overview**
> Updates Prysm systemd cmdline generation to avoid duplicate file logging.
> 
> Beacon now passes `--disable-ephemeral-log-file=true` and no longer sets an explicit `--log-file`, and validator similarly drops its `--log-file` argument, relying on the surrounding service logging/redirection instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c87d9010f9bef798dad8429a7aec4bbf0e8cff89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->